### PR TITLE
Update mssql-tools director to new mssql-tools18 directory

### DIFF
--- a/petstore-api-mssql/docker-compose.yaml
+++ b/petstore-api-mssql/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: "samplepwd!A1"
     healthcheck:
-      test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "samplepwd!A1" -Q "SELECT * FROM pets.pets" -b -o /dev/null
+      test: /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "samplepwd!A1" -Q "SELECT * FROM pets.pets" -b -o /dev/null
       interval: 10s
       timeout: 3s
       retries: 10

--- a/petstore-api-mssql/mssql-docker/setup.sh
+++ b/petstore-api-mssql/mssql-docker/setup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # Wait for database to startup
 sleep 30
-/opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P samplepwd!A1 -i init-schema.sql
+/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U SA -P samplepwd!A1 -i init-schema.sql


### PR DESCRIPTION
Fixes the breaking change introduced in SQL Server 2022 (16.x) CU 14 and SQL Server 2019 (15.x) CU 28 onward, with the `mssql-tools` directory being replaced by the `mssql-tools18` directory and needing the `-C` flag now to explicitly trust the certificate, and get around the `certificate verify failed:self-signed certificate error`.

See issue: https://github.com/microsoft/mssql-docker/issues/892
and comment: https://github.com/microsoft/mssql-docker/issues/892#issuecomment-2253179915